### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/contributions/core-webapp/src/main/java/com/cloudsuites/framework/webapp/authentication/SecurityConfiguration.java
+++ b/contributions/core-webapp/src/main/java/com/cloudsuites/framework/webapp/authentication/SecurityConfiguration.java
@@ -152,7 +152,7 @@ public class SecurityConfiguration {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, UserRoleRepository userRoleRepository) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/v1/auth/**"))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()


### PR DESCRIPTION
Potential fix for [https://github.com/cheeksnpeeps/cloudsuites/security/code-scanning/1](https://github.com/cheeksnpeeps/cloudsuites/security/code-scanning/1)

To resolve the flagged error, **do not globally disable CSRF protection**. Instead, allow Spring Security’s default CSRF protection to remain enabled. For endpoints (APIs) that need to remain accessible to non-browser clients—especially those using JWTs via headers—configure CSRF to ignore those endpoints if appropriate, using `.csrf(csrf -> csrf.ignoringRequestMatchers(...))`. This maintains the default protection for endpoints where it is needed, while allowing stateless JWT endpoints to function without unnecessary CSRF validation.

**Step-by-step fix:**
1. Remove or modify `.csrf(AbstractHttpConfigurer::disable)` on line 155.
2. If your API endpoints under `/api/v1/auth/**` and other public endpoints truly serve only non-browser clients, you can instruct CSRF to ignore those specific paths like this:
   ```java
   .csrf(csrf -> csrf.ignoringRequestMatchers("/api/v1/auth/**"))
   ```
   This enables CSRF for all other requests except those matched.
3. If you want CSRF protection for all endpoints, simply remove the `.csrf()` line—Spring Security will enable it by default.
4. Ensure any authentication architecture using cookies or browser-accessible storage for credentials does not bypass CSRF inadvertently.

**Change location:**  
Edit lines 154–155 in `SecurityConfiguration.java`, in the `securityFilterChain` method only.

**Required methods/imports/definitions:**  
No new imports or definitions are required. Only the lambda for `.csrf` may need to be adjusted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
